### PR TITLE
build: fix version declarations

### DIFF
--- a/tinybasic-doc/info.rkt
+++ b/tinybasic-doc/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 (define collection "tinybasic")
-(define version "1.0.0")
+(define version "1.0")
 (define deps '("base"
                "scribble-lib"
                "tinybasic-lib"

--- a/tinybasic-examples/info.rkt
+++ b/tinybasic-examples/info.rkt
@@ -1,5 +1,5 @@
 #lang info
 (define collection "tinybasic")
-(define version "1.0.0")
+(define version "1.0")
 (define deps '("base"
                "tinybasic-lib"))

--- a/tinybasic-lib/info.rkt
+++ b/tinybasic-lib/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 (define collection "tinybasic")
-(define version "1.0.0")
+(define version "1.0")
 (define deps '("base" "parser-tools-lib" "readline-lib"))
 (define racket-launcher-names '("tinybasic"))
 (define racket-launcher-libraries '("main.rkt"))

--- a/tinybasic/info.rkt
+++ b/tinybasic/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 (define collection "tinybasic")
-(define version "1.0.0")
+(define version "1.0")
 (define deps '("tinybasic-lib"
                "tinybasic-doc"
                "tinybasic-examples"))


### PR DESCRIPTION
I've recently [changed] `raco setup` to report invalid package versions (according to this [spec]) and I'm slowly going through all published packages that have version issues to fix them in anticipation of that change being released in 8.9.

[changed]: https://github.com/racket/racket/pull/4588
[spec]: https://docs.racket-lang.org/version/index.html#%28def._%28%28lib._version%2Futils..rkt%29._valid-version~3f%29%29