### PR TITLE
fix dependencies, add license

### DIFF
--- a/tinybasic-doc/info.rkt
+++ b/tinybasic-doc/info.rkt
@@ -1,8 +1,9 @@
 #lang info
 (define collection "tinybasic")
 (define version "1.0")
-(define deps '("base"
-               "scribble-lib"
-               "tinybasic-lib"
-               "racket-doc"))
+(define deps '("base"))
+(define build-deps '("scribble-lib"
+                     "tinybasic-lib"
+                     "racket-doc"))
 (define scribblings '(("scribblings/tinybasic.scrbl" () (language))))
+(define license 'MIT)

--- a/tinybasic-examples/info.rkt
+++ b/tinybasic-examples/info.rkt
@@ -3,3 +3,4 @@
 (define version "1.0")
 (define deps '("base"
                "tinybasic-lib"))
+(define license 'MIT)

--- a/tinybasic-lib/info.rkt
+++ b/tinybasic-lib/info.rkt
@@ -4,3 +4,4 @@
 (define deps '("base" "parser-tools-lib" "readline-lib"))
 (define racket-launcher-names '("tinybasic"))
 (define racket-launcher-libraries '("main.rkt"))
+(define license 'MIT)

--- a/tinybasic/info.rkt
+++ b/tinybasic/info.rkt
@@ -1,6 +1,11 @@
 #lang info
 (define collection "tinybasic")
 (define version "1.0")
-(define deps '("tinybasic-lib"
+(define deps '("base"
+               "tinybasic-lib"
                "tinybasic-doc"
                "tinybasic-examples"))
+(define implies '("tinybasic-lib"
+                  "tinybasic-doc"
+                  "tinybasic-examples"))
+(define license 'MIT)


### PR DESCRIPTION
This pr fixes some dependency issues in `info.rkt` files in some of the packages.

- get rid of unused dependencies
- move dependencies to build phase where possible
- introduce undeclared dependencies
- add `implies` declaration in meta package

also make explicit the MIT license, this package is licensed under.